### PR TITLE
Added dynamic differenc from left and right bottom result

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1,237 +1,3 @@
-const id_names = {
-    "left": {
-        "50000": {
-            "currencyUnit": "currencyUnit_left_50000",
-            "quantityUnit": "quantityUnit_left_50000",
-            "product": "product_left_50000",
-        },
-        "20000": {
-            "currencyUnit": "currencyUnit_left_20000",
-            "quantityUnit": "quantityUnit_left_20000",
-            "product": "product_left_20000",
-        },
-        "10000": {
-            "currencyUnit": "currencyUnit_left_10000",
-            "quantityUnit": "quantityUnit_left_10000",
-            "product": "product_left_10000",
-        },
-        "5000": {
-            "currencyUnit": "currencyUnit_left_5000",
-            "quantityUnit": "quantityUnit_left_5000",
-            "product": "product_left_5000",
-        },
-        "2000": {
-            "currencyUnit": "currencyUnit_left_2000",
-            "quantityUnit": "quantityUnit_left_2000",
-            "product": "product_left_2000",
-        },
-        "1000": {
-            "currencyUnit": "currencyUnit_left_1000",
-            "quantityUnit": "quantityUnit_left_1000",
-            "product": "product_left_1000",
-        },
-        "500": {
-            "currencyUnit": "currencyUnit_left_500",
-            "quantityUnit": "quantityUnit_left_500",
-            "product": "product_left_500",
-        },
-        "200": {
-            "currencyUnit": "currencyUnit_left_200",
-            "quantityUnit": "quantityUnit_left_200",
-            "product": "product_left_200",
-        },
-        "100": {
-            "currencyUnit": "currencyUnit_left_100",
-            "quantityUnit": "quantityUnit_left_100",
-            "product": "product_left_100",
-        },
-        "50": {
-            "currencyUnit": "currencyUnit_left_50",
-            "quantityUnit": "quantityUnit_left_50",
-            "product": "product_left_50",
-        },
-        "20": {
-            "currencyUnit": "currencyUnit_left_20",
-            "quantityUnit": "quantityUnit_left_20",
-            "product": "product_left_20",
-        },
-        "10": {
-            "currencyUnit": "currencyUnit_left_10",
-            "quantityUnit": "quantityUnit_left_10",
-            "product": "product_left_10",
-        },
-        "5": {
-            "currencyUnit": "currencyUnit_left_5",
-            "quantityUnit": "quantityUnit_left_5",
-            "product": "product_left_5",
-        },
-        "2": {
-            "currencyUnit": "currencyUnit_left_2",
-            "quantityUnit": "quantityUnit_left_2",
-            "product": "product_left_2",
-        },
-        "1": {
-            "currencyUnit": "currencyUnit_left_1",
-            "quantityUnit": "quantityUnit_left_1",
-            "product": "product_left_1",
-        },
-    },
-    "middle": {
-        "50000": {
-            "currencyUnit": "currencyUnit_middle_50000",
-            "quantityUnit": "quantityUnit_middle_50000",
-            "product": "product_middle_50000",
-        },
-        "20000": {
-            "currencyUnit": "currencyUnit_middle_20000",
-            "quantityUnit": "quantityUnit_middle_20000",
-            "product": "product_middle_20000",
-        },
-        "10000": {
-            "currencyUnit": "currencyUnit_middle_10000",
-            "quantityUnit": "quantityUnit_middle_10000",
-            "product": "product_middle_10000",
-        },
-        "5000": {
-            "currencyUnit": "currencyUnit_middle_5000",
-            "quantityUnit": "quantityUnit_middle_5000",
-            "product": "product_middle_5000",
-        },
-        "2000": {
-            "currencyUnit": "currencyUnit_middle_2000",
-            "quantityUnit": "quantityUnit_middle_2000",
-            "product": "product_middle_2000",
-        },
-        "1000": {
-            "currencyUnit": "currencyUnit_middle_1000",
-            "quantityUnit": "quantityUnit_middle_1000",
-            "product": "product_middle_1000",
-        },
-        "500": {
-            "currencyUnit": "currencyUnit_middle_500",
-            "quantityUnit": "quantityUnit_middle_500",
-            "product": "product_middle_500",
-        },
-        "200": {
-            "currencyUnit": "currencyUnit_middle_200",
-            "quantityUnit": "quantityUnit_middle_200",
-            "product": "product_middle_200",
-        },
-        "100": {
-            "currencyUnit": "currencyUnit_middle_100",
-            "quantityUnit": "quantityUnit_middle_100",
-            "product": "product_middle_100",
-        },
-        "50": {
-            "currencyUnit": "currencyUnit_middle_50",
-            "quantityUnit": "quantityUnit_middle_50",
-            "product": "product_middle_50",
-        },
-        "20": {
-            "currencyUnit": "currencyUnit_middle_20",
-            "quantityUnit": "quantityUnit_middle_20",
-            "product": "product_middle_20",
-        },
-        "10": {
-            "currencyUnit": "currencyUnit_middle_10",
-            "quantityUnit": "quantityUnit_middle_10",
-            "product": "product_middle_10",
-        },
-        "5": {
-            "currencyUnit": "currencyUnit_middle_5",
-            "quantityUnit": "quantityUnit_middle_5",
-            "product": "product_middle_5",
-        },
-        "2": {
-            "currencyUnit": "currencyUnit_middle_2",
-            "quantityUnit": "quantityUnit_middle_2",
-            "product": "product_middle_2",
-        },
-        "1": {
-            "currencyUnit": "currencyUnit_middle_1",
-            "quantityUnit": "quantityUnit_middle_1",
-            "product": "product_middle_1",
-        },
-    },
-    "right": {
-        "50000": {
-            "currencyUnit": "currencyUnit_right_50000",
-            "quantityUnit": "quantityUnit_right_50000",
-            "product": "product_right_50000",
-        },
-        "20000": {
-            "currencyUnit": "currencyUnit_right_20000",
-            "quantityUnit": "quantityUnit_right_20000",
-            "product": "product_right_20000",
-        },
-        "10000": {
-            "currencyUnit": "currencyUnit_right_10000",
-            "quantityUnit": "quantityUnit_right_10000",
-            "product": "product_right_10000",
-        },
-        "5000": {
-            "currencyUnit": "currencyUnit_right_5000",
-            "quantityUnit": "quantityUnit_right_5000",
-            "product": "product_right_5000",
-        },
-        "2000": {
-            "currencyUnit": "currencyUnit_right_2000",
-            "quantityUnit": "quantityUnit_right_2000",
-            "product": "product_right_2000",
-        },
-        "1000": {
-            "currencyUnit": "currencyUnit_right_1000",
-            "quantityUnit": "quantityUnit_right_1000",
-            "product": "product_right_1000",
-        },
-        "500": {
-            "currencyUnit": "currencyUnit_right_500",
-            "quantityUnit": "quantityUnit_right_500",
-            "product": "product_right_500",
-        },
-        "200": {
-            "currencyUnit": "currencyUnit_right_200",
-            "quantityUnit": "quantityUnit_right_200",
-            "product": "product_right_200",
-        },
-        "100": {
-            "currencyUnit": "currencyUnit_right_100",
-            "quantityUnit": "quantityUnit_right_100",
-            "product": "product_right_100",
-        },
-        "50": {
-            "currencyUnit": "currencyUnit_right_50",
-            "quantityUnit": "quantityUnit_right_50",
-            "product": "product_right_50",
-        },
-        "20": {
-            "currencyUnit": "currencyUnit_right_20",
-            "quantityUnit": "quantityUnit_right_20",
-            "product": "product_right_20",
-        },
-        "10": {
-            "currencyUnit": "currencyUnit_right_10",
-            "quantityUnit": "quantityUnit_right_10",
-            "product": "product_right_10",
-        },
-        "5": {
-            "currencyUnit": "currencyUnit_right_5",
-            "quantityUnit": "quantityUnit_right_5",
-            "product": "product_right_5",
-        },
-        "2": {
-            "currencyUnit": "currencyUnit_right_2",
-            "quantityUnit": "quantityUnit_right_2",
-            "product": "product_right_2",
-        },
-        "1": {
-            "currencyUnit": "currencyUnit_right_1",
-            "quantityUnit": "quantityUnit_right_1",
-            "product": "product_right_1",
-        },
-    },
-}
-
 const product_nodes = {
     "left": document.querySelectorAll('.quantityUnit_left'),
     "middle": document.querySelectorAll('.quantityUnit_middle'),
@@ -268,26 +34,36 @@ function calc_product_on_keyup(event) {
     let column_container = event.path[2];
     let product_nodes = column_container.querySelectorAll(
         '.product_left, .product_middle, .product_right'
-        );
-        
-        let sum = 0;
-        for (let i = 0; i < 15; i++) {
-            sum += parseFloat(product_nodes[i].innerHTML)
-        }
-        
-    // write result
-    let product_sum_container = column_container.querySelectorAll(
+    );
+
+    let sum = 0;
+    for (let i = 0; i < 15; i++) {
+        sum += parseFloat(product_nodes[i].innerHTML)
+    };
+
+    // write product result to bottom complete_sum div
+    let complete_sum_container = column_container.querySelectorAll(
         '#complete_sum_left, #complete_sum_middle, #complete_sum_right'
-        );
-    product_sum_container[0].innerHTML = sum
+    );
+    complete_sum_container[0].innerHTML = sum;
+
+    // calculate difference from right and left complete_sum and write it to 
+    // middle complete_sum
+    let complete_sum_left = document.getElementById("complete_sum_left");
+    let complete_sum_right = document.getElementById("complete_sum_right");
+    let complete_sum_middle = document.getElementById("complete_sum_middle");
+    //let complete_sum_left = document.getElementById("complete_checksum_middle");
+
+    complete_sum_middle.innerHTML = parseFloat(complete_sum_left.innerHTML)
+        - parseFloat(complete_sum_right.innerHTML);
 }
+
+// add eventListener to all left column input nodes
+for (let x of product_nodes["left"]) {
+    x.addEventListener("keyup", function (event) { calc_product_on_keyup(event) });
+};
 
 // add eventListener to all right column input nodes
-
-for (let x of product_nodes["left"]){
-    x.addEventListener("keyup", function (event) { calc_product_on_keyup(event) })
-}
-
-for (let x of product_nodes["right"]){
-    x.addEventListener("keyup", function (event) { calc_product_on_keyup(event) })
-}
+for (let x of product_nodes["right"]) {
+    x.addEventListener("keyup", function (event) { calc_product_on_keyup(event) });
+};


### PR DESCRIPTION
The function `calc_product_on_keyup` is already able to calculate row-wise products and sums up all products on keyup events and prints those results to the corresponding div element at the bottom.

The bottom results are now calculatet as difference from bottom results (right - left) on every keyup event. This is automatically printed out to the middle div element at the bottom.